### PR TITLE
Use test unit explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
 - 2.0.0
+- 2.1
+- 2.2
 script:
 - bundle install
 - bundle exec rake

--- a/fluent-plugin-dd.gemspec
+++ b/fluent-plugin-dd.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'test-unit', '>= 3.1.0'
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible layer.
