### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_dd.rb
+++ b/lib/fluent/plugin/out_dd.rb
@@ -5,8 +5,8 @@ class Fluent::DdOutput < Fluent::BufferedOutput
     define_method('log') { $log }
   end
 
-  config_param :dd_api_key, :string
-  config_param :dd_app_key, :string, :default => nil
+  config_param :dd_api_key, :string, :secret => true
+  config_param :dd_app_key, :string, :default => nil, :secret => true
   config_param :host, :string, :default => nil
   config_param :device, :string, :default => nil
   config_param :silent, :bool, :default => true


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameters feature.
`:secret => true` specified parameters will be replaced with xxxxxx in log.

If you use older fluentd, `:secret => true` specified parameters will be simply ignored.
