### PR TITLE
Use `@type` instead of `type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Output plugin for Datadog
 
 ```
 <match datadog.**>
-  type dd
+  @type dd
   dd_api_key ...
   #dd_app_key_key ...
   #host my_host.example.com


### PR DESCRIPTION
Because `type` parameter is deprecated.