### PR TITLE
Rewrite as asynchronous buffered output plugin

### DIFF
--- a/lib/fluent/plugin/out_dd.rb
+++ b/lib/fluent/plugin/out_dd.rb
@@ -1,6 +1,5 @@
 require 'dogapi'
 require 'socket'
-require 'thread'
 require 'fluent/plugin/output'
 
 class Fluent::Plugin::DdOutput < Fluent::Plugin::Output

--- a/lib/fluent/plugin/out_dd.rb
+++ b/lib/fluent/plugin/out_dd.rb
@@ -9,15 +9,15 @@ class Fluent::Plugin::DdOutput < Fluent::Plugin::Output
 
   DEFAULT_BUFFER_TYPE = "memory"
 
-  config_param :dd_api_key, :string, :secret => true
-  config_param :dd_app_key, :string, :default => nil, :secret => true
-  config_param :host, :string, :default => nil
-  config_param :device, :string, :default => nil
-  config_param :silent, :bool, :default => true
-  config_param :timeout, :integer, :default => nil
-  config_param :use_fluentd_tag_for_datadog_tag, :bool, :default => false
-  config_param :emit_in_background, :bool, :default => false
-  config_param :concurrency, :integer, :default => nil
+  config_param :dd_api_key, :string, secret: true
+  config_param :dd_app_key, :string, default: nil, secret: true
+  config_param :host, :string, default: nil
+  config_param :device, :string, default: nil
+  config_param :silent, :bool, default: true
+  config_param :timeout, :integer, default: nil
+  config_param :use_fluentd_tag_for_datadog_tag, :bool, default: false
+  config_param :emit_in_background, :bool, default: false
+  config_param :concurrency, :integer, default: nil
 
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,6 @@ def run_driver(options = {})
   }.join("\n")
 
   fluentd_conf = <<-EOS
-type datadog
 dd_api_key #{dd_api_key}
 host #{host}
 #{additional_options}
@@ -35,7 +34,7 @@ host #{host}
   tag = options[:tag] || 'test.default'
   driver = Fluent::Test::Driver::Output.new(Fluent::Plugin::DdOutput).configure(fluentd_conf)
 
-  driver.run(default_tag: tag) do
+  driver.run(default_tag: tag, wait_flush_completion: false, shutdown: false) do
     dog = driver.instance.instance_variable_get(:@dog)
     yield(driver, dog)
   end


### PR DESCRIPTION
In previous version, we can post data to DataDog API
asynchronously, but we cannot retry posting data to DataDog API.
In this version, we can post data to DataDog API asynchronously,
and we can retry posting data to DataDog API.

See https://docs.fluentd.org/plugin-development/api-plugin-output